### PR TITLE
ban whosonfirst.mapzen.com labels

### DIFF
--- a/style.yaml
+++ b/style.yaml
@@ -191,7 +191,9 @@ layers:
     places:
         data: { source: mapzen, layer: places }
         filter:
-            name: true
+            all:
+                - name: true
+                - not: {source: [whosonfirst.mapzen.com]}
         draw:
             text:
                 text_source: global.name_source


### PR DESCRIPTION
low quality nonOSM source - duplicate, malformed, invalid labels unfixable in OSM would be confusing for OSM editors

see https://github.com/tilezen/vector-datasource/issues/1410 https://github.com/whosonfirst-data/whosonfirst-data/issues/1008 https://github.com/whosonfirst-data/whosonfirst-data/issues/1022 https://github.com/tilezen/vector-datasource/issues/1418

fixes #14