### PR TITLE
ban whosonfirst.mapzen.com labels

### DIFF
--- a/layers/labels.yaml
+++ b/layers/labels.yaml
@@ -19,7 +19,7 @@ layers:
     places:
         data: { source: mapzen}
         places-labels:
-            filter: { name: true }
+            filter: {name: true, not: {source: [whosonfirst.org]}}
             draw:
                 text:
                     text_source: global.name_source


### PR DESCRIPTION
low quality nonOSM source - duplicate, malformed, invalid labels unfixable in OSM would be confusing for OSM editors

see tilezen/vector-datasource#1410 whosonfirst-data/whosonfirst-data#1008 whosonfirst-data/whosonfirst-data#1022 tilezen/vector-datasource#1418

fixes #14 (again), repeats #26 - but source marker changed

fixes https://github.com/westnordost/StreetComplete/issues/1527

tested in tangram play