### PR TITLE
very minor refactoring

### DIFF
--- a/layers/labels.yaml
+++ b/layers/labels.yaml
@@ -11,10 +11,10 @@ layers:
                     max_lines: 3
                     font:
                         family: global.text_font_family
-                        weight: normal
                         fill: global.text_fill_color
                         size: global.text_size
                         stroke: global.text_stroke
+                        weight: normal
 
     places:
         data: { source: mapzen}
@@ -25,8 +25,8 @@ layers:
                     text_source: global.name_source
                     buffer: 12px
                     font:
-                        fill: global.text_fill_color
                         family: global.text_font_family
+                        fill: global.text_fill_color
                         stroke: global.text_places_stroke
 
     buildings:
@@ -37,7 +37,7 @@ layers:
                 text:
                     text_source: addr_housenumber
                     font:
-                        fill: global.text_fill_color
                         family: global.text_font_family
+                        fill: global.text_fill_color
                         size: global.text_size
                         stroke: global.text_stroke

--- a/layers/labels.yaml
+++ b/layers/labels.yaml
@@ -27,6 +27,7 @@ layers:
                     font:
                         family: global.text_font_family
                         fill: global.text_fill_color
+                        size: global.text_size
                         stroke: global.text_places_stroke
 
     buildings:

--- a/streetcomplete-dark-style.yaml
+++ b/streetcomplete-dark-style.yaml
@@ -18,9 +18,9 @@ global:
 
     railway_color: '#903'
     road_color: '#559'
+    road_outline_color: '#99f'
     highway_color: '#033'
     highway_outline_color: '#000'
-    road_outline_color: '#99f'
     path_color: global.road_color
     path_outline_color: '#547'
     square_color: global.road_color


### PR DESCRIPTION
This should not change any behavior but new ordering of parameters should be more consistent.

"apply text_size also to place labels" should not change anything for now as 12px is default anyway, but makes future changes less confusing (I just run into it during making PR that would make text larger as one zooms in).


BTW, I plan to submit also PR that would remove from `global.yaml` things that are fully overwritten anyway to make it less confusing.

-----

My work on this pull request was sponsored by a NGI Zero Discovery [grant](https://www.openstreetmap.org/user/Mateusz%20Konieczny/diary/368849)