### PR TITLE
Resizing text

### DIFF
--- a/global.yaml
+++ b/global.yaml
@@ -1,5 +1,5 @@
 global:
-    language: false
+    language: false # intended to be overwritten by StreetComplete
     text_font_family: 'Montserrat'
     text_stroke_color: 'white'
     text_stroke: { color: global.text_stroke_color, width: 2.5px }

--- a/global.yaml
+++ b/global.yaml
@@ -5,7 +5,17 @@ global:
     text_stroke: { color: global.text_stroke_color, width: 2.5px }
     text_places_stroke: { color: global.text_stroke_color, width: 2.5px }
     text_fill_color: '#124'
-    text_size: 12px
+    text_size_scaling: 1 # intended to be overwritten by StreetComplete
+    text_size: |
+      function() {
+        var size = 13;
+        if ($zoom >= 18 && $zoom < 19) {
+          size = 15;
+        } else if ($zoom >= 19) {
+          size = 17;
+        }
+        return (size * global.text_size_scaling) + "px";
+      }
 
     # The following colors are in most cases overwritten
     # ones that are used are defined in streetcomplete-light-style.yaml


### PR DESCRIPTION
Add support for scaling text size (to support for example system-wide text scaling).

Increases text size across all zoom levels for all labels (small change 12->13).

Increases text size at high zoom levels (subtle increase, to not scare people away from that change - though I would be OK also with a more radical change)

Thanks to @ENT8R for finding bug in my code and finding superior solution to what I had.

Changes are quantized as it appears that `$zoom` is quantized anyway (i tested https://github.com/ENT8R/streetcomplete-mapstyle/commit/5dcfd3226faffc68656daf26b4a0fe747bcb7cca#commitcomment-39607570 - though feel free to double check that)

I used

```
    name_source: |
        function() {
            return $zoom;
        }
```

to confirm that `$zoom` is an integer.