### PR TITLE
adapt jawg stylesheet to v2

### DIFF
--- a/global.yaml
+++ b/global.yaml
@@ -56,13 +56,13 @@ global:
             var userLang = global.language;
             if (userLang) {
                 // Preference #1: Take name in own language (f.e. name:en used in Egypt a lot)
-                var nameInUserLang = feature['name:'+userLang];
+                var nameInUserLang = feature['name_'+userLang];
                 if (nameInUserLang) return nameInUserLang;
                 
                 // find language of name of element
                 var elementLang;
                 var name = feature["name"];
-                var localizedNameRegex = /^name:([a-z]{2,3})$/;
+                var localizedNameRegex = /^name_([a-z]{2,3})$/;
                 for (key of Object.keys(feature)) {
                     if (key == "name") continue;
                     if (name == feature[key]) {
@@ -77,24 +77,26 @@ global:
                 if (elementLang && elementLang != userLang) {
                     var userScript = global.language_script;
                     
+                    // Preference #2 and #3 are not available in JawgMaps
+                    
                     // Preference #2: Take international name (f.e. used in Greece a lot)
-                    var internationalName = feature["int_name"];
-                    if (internationalName) return internationalName;
+                    //var internationalName = feature["int_name"];
+                    //if (internationalName) return internationalName;
                     
                     // Preference #3: Take name that is readable in user's script, usually romanized name. Used in Japan a lot
-                    var nameInUserScript = feature["name:" + elementLang + "-" + userScript];
-                    if (nameInUserScript) return nameInUserScript;
+                    //var nameInUserScript = feature["name_" + elementLang + "-" + userScript];
+                    //if (nameInUserScript) return nameInUserScript;
                     // NOTE: more correct would be to check elementScript != userScript but the elementScript is hard to find out in pure JavaScript
                     
                     // Preference #4: Take name in English (cause it's kind of the "international") language
                     if (userLang != "en") {
-                        var nameInEnglish = feature["name:en"]
+                        var nameInEnglish = feature["name_en"]
                         if (nameInEnglish) return nameInEnglish;
                     }
                     
                     // Preference #5: Take name that is readable in Latin (cause it's kind of "international") script
                     if (userScript != "Latn") {
-                        var nameInLatinScript = feature["name:" + elementLang + "-Latn"];
+                        var nameInLatinScript = feature["name_ltn"];
                         if (nameInLatinScript) return nameInLatinScript;
                     }
                     

--- a/global.yaml
+++ b/global.yaml
@@ -28,9 +28,9 @@ global:
     road_color: '#fff'
     highway_color: '#fa8'
     highway_outline_color: global.road_outline_color
-    road_outline_color: '#996666'
+    road_outline_color: '#a88'
     path_color: global.road_color
-    path_outline_color: '#e0c9b3'
+    path_outline_color: '#ca9'
     square_color: global.road_color
     square_outline_color: global.path_outline_color
 

--- a/global.yaml
+++ b/global.yaml
@@ -138,8 +138,7 @@ lights:
 sources:
     jawg:
         type: MVT
-        url: https://{s}.tile.jawg.io/streets-v1+hillshade-v1/{z}/{x}/{y}.pbf
-        url_subdomains: [a, b, c]
+        url: https://tile.jawg.io/streets-v2/{z}/{x}/{y}.pbf
         max_zoom: 16
         url_params:
             access-token: global.api_key

--- a/layers/labels.yaml
+++ b/layers/labels.yaml
@@ -1,6 +1,6 @@
 layers:
     road-labels:
-        data: { source: jawg, layer: road_label }
+        data: { source: jawg, layer: road }
         filter: { $zoom: { min: 14 } }
         draw:
             text:
@@ -16,10 +16,10 @@ layers:
                     stroke: global.text_stroke
                     weight: normal
 
-    # jawg: state_label, mountain_peak, poi_label (w/ type=, zoomrank=) exists
+    # jawg: natural_label, poi_label (w/ type=, zoomrank=) exists
 
     water-labels:
-        data: { source: jawg, layer: [waterway_label, waterarea_label] }
+        data: { source: jawg, layer: [waterway, water] }
         filter: { $zoom: { min: 14 } }
         draw:
             text:
@@ -32,7 +32,8 @@ layers:
                     size: global.text_size
                     stroke: global.text_water_stroke
     marine-labels:
-        data: { source: jawg, layer: marine_label }
+        data: { source: jawg, layer: natural_label }
+        filter: { class: [ocean, sea] }
         draw:
             text:
                 text_source: global.name_source
@@ -46,7 +47,8 @@ layers:
                     transform: uppercase
 
     country-labels:
-        data: { source: jawg, layer: country_label }
+        data: { source: jawg, layer: place_label }
+        filter: { class: country }
         draw:
             text:
                 text_source: global.name_source
@@ -62,6 +64,7 @@ layers:
 
     place-labels:
         data: { source: jawg, layer: place_label }
+        filter: { not: { class: country } }
         draw:
             text:
                 text_source: global.name_source
@@ -92,10 +95,3 @@ layers:
                     fill: global.text_fill_color
                     size: global.text_size
                     stroke: global.text_stroke
-
-global:
-    name_source: |
-        function() {
-            // Use preferred language label if available
-            return (global.language && feature['name_'+global.language]) || feature.name;
-        }

--- a/layers/land.yaml
+++ b/layers/land.yaml
@@ -92,24 +92,23 @@ layers:
                     color: global.forest_color
 
     barriers:
-        data: { source: jawg , layer: structure }
+        data: { source: jawg, layer: structure }
         city_walls:
-            # jawg: doesn't work, city walls are transformed into fences
-            filter: { class: [city_wall, dam, cliff] }
+            filter: { type: [city_wall, dam, cliff] }
             draw:
                 buildings-outline-style:
                     order: 100
                     color: global.building_outline_color
                     width: [[12, 4px], [18, 8m]]
         walls:
-            filter: { class: [wall, retaining_wall, fence] }
+            filter: { class: fence, not: { type: city_wall }}
             draw:
                 buildings-outline-style:
                     order: 100
                     color: global.building_outline_color
                     width: [[15, 1px], [18, 2m]]
         hedge:
-            filter: { class: [hedge, hedge_bank] }
+            filter: { class: hedge }
             draw:
                 buildings-outline-style:
                     order: 100

--- a/layers/land.yaml
+++ b/layers/land.yaml
@@ -2,7 +2,7 @@ layers:
 
     boundaries:
         data: { source: jawg, layer: admin }
-        filter: { admin_level: 2, not: { maritime: 1 }}
+        filter: { admin_level: 2, not: { maritime: true }}
         draw:
             boundary_dashes:
                 order: 80

--- a/layers/land.yaml
+++ b/layers/land.yaml
@@ -9,25 +9,9 @@ layers:
                 color: global.boundary_color
                 width: 1px
 
-    waterareas:
-        data: { source: jawg , layer: waterarea }
-        filter: { not: { tunnel: 1 }}
-        draw:
-            polygons:
-                order: 4
-                color: global.water_color
-
-        shore_lines:
-            filter: { $zoom: { min: 16 } }
-            draw:
-                lines-coast:
-                    order: 5
-                    width: [[16,20px],[18,10m]] # actually visually 1/3
-                    color: global.water_color
-
     water:
-        data: { source: jawg }
-        filter: { not: { tunnel: 1 }}
+        data: { source: jawg, layer: water }
+        filter: { not: { structure: tunnel }}
         draw:
             polygons:
                 order: 4
@@ -43,7 +27,7 @@ layers:
 
     waterways:
         data: { source: jawg, layer: waterway }
-        filter: { not: { tunnel: 1 }}
+        filter: { not: { structure: tunnel }}
         draw:
             lines:
                 order: 5
@@ -80,7 +64,8 @@ layers:
                 extrude: true
 
     landuse:
-        data: { source: jawg }
+        data: { source: jawg, layer: landuse }
+        filter: { not: { class: national_park }}
         draw:
             polygons:
                 order: 1
@@ -107,10 +92,10 @@ layers:
                     color: global.forest_color
 
     barriers:
-        data: { source: jawg , layer: barrier_line }
+        data: { source: jawg , layer: structure }
         city_walls:
             # jawg: doesn't work, city walls are transformed into fences
-            filter: { class: [city_wall, dam] }
+            filter: { class: [city_wall, dam, cliff] }
             draw:
                 buildings-outline-style:
                     order: 100

--- a/layers/land.yaml
+++ b/layers/land.yaml
@@ -35,14 +35,14 @@ layers:
                 cap: square
 
         river_lines:
-            filter: { class: [river, canal, river_intermittent] }
+            filter: { class: [river, canal] }
             draw:
                 lines:
                     color: global.water_color
                     width: [[10, 1px], [17, 6px], [18, 12m]]
 
         stream_lines:
-            filter: { class: [stream, stream_intermittent, ditch, drain], $zoom: { min: 15 }}
+            filter: { class: [stream, ditch, drain], $zoom: { min: 15 }}
             draw:
                 lines:
                     color: global.water_color

--- a/layers/roads.yaml
+++ b/layers/roads.yaml
@@ -128,7 +128,7 @@ layers:
                         style: private-way
 
         oneway:
-            filter: { not: { oneway: 0 }, $zoom: { min: 17 } }
+            filter: { not: { oneway: false }, $zoom: { min: 17 } }
             draw:
                 oneway-arrow:
                     flat: true

--- a/layers/roads.yaml
+++ b/layers/roads.yaml
@@ -160,26 +160,18 @@ layers:
                     outline:
                         order: 21
 
-    pois:
+    point_barriers:
         # jawg: these do not exist
-        data: { source: jawg , layer: poi }
+        data: { source: jawg , layer: structure }
         barrier:
-            filter: { type: [gate, bollard, lift_gate, cycle_barrier, stile, block, toll_booth, kissing_gate, swing_gate, chain, cattle_grid, border_control], $zoom: { min: 17 }}
+            filter: { class: gate, $zoom: { min: 17 }}
             draw:
                 points:
                     buffer: 2px
                     flat: true
                     color: global.barrier_color
                     size: [[17, 2px], [20, 16px]]
-        roundabout:
-            # jawg these do not seem to exist
-            filter: { type: [mini_roundabout, turning_loop, turning_circle] }
-            draw:
-                points:
-                    buffer: 2px
-                    flat: true
-                    color: global.roundabout_color
-                    size: [[16, 2px], [20, 24px]]
+         # jawg mini_roundabout, turning_loop, turning_circle do not exist
 
 styles:
     step_dashes:

--- a/layers/roads.yaml
+++ b/layers/roads.yaml
@@ -1,7 +1,7 @@
 layers:
     railway:
         data: { source: jawg, layer: road }
-        filter: { class: [major_rail, minor_rail], not: { tunnel: 1 }}
+        filter: { class: [major_rail, minor_rail], not: { structure: tunnel }}
         draw:
             lines-railway-style:
                 order: 32
@@ -10,7 +10,7 @@ layers:
                 width: [[10, 0.5px], [12, 1.0px], [13, 2px], [18, 3m]]
         # jawg: no filtering between service rail and other possible
         bridges:
-            filter: { bridge: 1 }
+            filter: { structure: bridge }
             draw:
                 lines-railway-style:
                     order: 42
@@ -31,7 +31,7 @@ layers:
                     order: 35
 
         bridges:
-            filter: { bridge: 1 }
+            filter: { structure: bridge }
             draw:
                 lines:
                     order: 44
@@ -39,7 +39,7 @@ layers:
                         cap: butt
                         order: 45
         tunnel:
-            filter: { tunnel: 1 }
+            filter: { structure: tunnel }
             draw:
                 lines-highway-style:
                     order: 22
@@ -120,7 +120,12 @@ layers:
                         width: function () { return 1/4 * Math.log($zoom); }
                         order: 31
 
-        # jawg: no property for private roads
+        private:
+            filter: { access: [no, private, destination, customers, delivery, agricultural, forestry, emergency] }
+            draw:
+                lines:
+                    outline:
+                        style: private-way
 
         oneway:
             filter: { not: { oneway: 0 }, $zoom: { min: 17 } }
@@ -137,7 +142,7 @@ layers:
                         visible: false
 
         bridges:
-            filter: { bridge: 1 }
+            filter: { structure: bridge }
             draw:
                 lines:
                     order: 40
@@ -146,7 +151,7 @@ layers:
                         order: 41
 
         tunnel:
-            filter: { tunnel: 1 }
+            filter: { structure: tunnel }
             draw:
                 lines:
                     order: 20

--- a/layers/roads.yaml
+++ b/layers/roads.yaml
@@ -187,6 +187,7 @@ styles:
     private-way:
         base: lines
         dash: [1.0,0.5]
+        blend: translucent
     oneway-arrow:
         base: points
         texture: oneway-arrow

--- a/streetcomplete-light-style.yaml
+++ b/streetcomplete-light-style.yaml
@@ -15,9 +15,9 @@ import:
 global:
     railway_color: '#99a'
     road_color: '#fff'
-    road_outline_color: '#966'
+    road_outline_color: '#a88'
     path_color: global.road_color
-    path_outline_color: '#e0c9b3'
+    path_outline_color: '#ca9'
     square_color: global.road_color
 
     earth_color: '#f3eacc'


### PR DESCRIPTION
v2 brings...
- better support for 3d buildings
- (better) l18n support
- housenumbers for housenumbers mapped on building outlines
- access-property for roads
- even smaller size

v2 is still in development though, I got to see an early preview.