### PR TITLE
Improve Contributing section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Every vector map tiles hoster has his own schema, so every map style is per se o
 
 ## Useful links
 
-* [View map & edit map style](https://streetcomplete.github.io/streetcomplete-mapstyle)
+* [View map & edit map style](https://streetcomplete.github.io/streetcomplete-mapstyle/?provider=jawg)
 * [Tangram documentation](https://mapzen.com/documentation/tangram/)
 * [Tangram Play](https://tangram.city/play/)
 * [Issue #183 of StreetComplete](https://github.com/westnordost/StreetComplete/issues/183) (The reason why this repository was created)

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Every vector map tiles hoster has his own schema, so every map style is per se o
 
 * Open the code in an editor
   * StreetComplete Map Style Editor
-   (recommended; [Normal map](https://streetcomplete.github.io/streetcomplete-mapstyle/?provider=jawg&style=light),  [Satellite map](https://streetcomplete.github.io/streetcomplete-mapstyle/?provider=jawg&style=satellite), [Dark map](https://tangram.city/play/?scene=https://raw.githubusercontent.com/ENT8R/streetcomplete-mapstyle/jawg/streetcomplete-dark-style.yaml))  
+   (recommended; [Normal map](https://streetcomplete.github.io/streetcomplete-mapstyle/?provider=jawg&style=light), [Satellite map](https://streetcomplete.github.io/streetcomplete-mapstyle/?provider=jawg&style=satellite), [Dark map](https://streetcomplete.github.io/streetcomplete-mapstyle/?provider=jawg&style=dark))  
    Already includes a jawg.io API key
   * Tangram Play ([Normal map](https://tangram.city/play/?scene=https://raw.githubusercontent.com/ENT8R/streetcomplete-mapstyle/jawg/streetcomplete-light-style.yaml),  [Satellite map](https://tangram.city/play/?scene=https://raw.githubusercontent.com/ENT8R/streetcomplete-mapstyle/jawg/streetcomplete-satellite-style.yaml), [Dark map](https://tangram.city/play/?scene=https://raw.githubusercontent.com/ENT8R/streetcomplete-mapstyle/jawg/streetcomplete-dark-style.yaml))  
     When using jawg.io, add your API key to the field `api_key` in the `global` section

--- a/README.md
+++ b/README.md
@@ -22,14 +22,19 @@ Every vector map tiles hoster has his own schema, so every map style is per se o
 
 ## Contributing
 
-* Open the code in Tangram Play ([Normal map](https://tangram.city/play/?scene=https://raw.githubusercontent.com/ENT8R/streetcomplete-mapstyle/jawg/streetcomplete-light-style.yaml),  [Satellite map](https://tangram.city/play/?scene=https://raw.githubusercontent.com/ENT8R/streetcomplete-mapstyle/jawg/streetcomplete-satellite-style.yaml), [Dark map](https://tangram.city/play/?scene=https://raw.githubusercontent.com/ENT8R/streetcomplete-mapstyle/jawg/streetcomplete-dark-style.yaml))
+* Open the code in an editor
+  * StreetComplete Map Style Editor
+   (recommended; [Normal map](https://streetcomplete.github.io/streetcomplete-mapstyle/?provider=jawg&style=light),  [Satellite map](https://streetcomplete.github.io/streetcomplete-mapstyle/?provider=jawg&style=satellite), [Dark map](https://tangram.city/play/?scene=https://raw.githubusercontent.com/ENT8R/streetcomplete-mapstyle/jawg/streetcomplete-dark-style.yaml))  
+   Already includes a jawg.io API key
+  * Tangram Play ([Normal map](https://tangram.city/play/?scene=https://raw.githubusercontent.com/ENT8R/streetcomplete-mapstyle/jawg/streetcomplete-light-style.yaml),  [Satellite map](https://tangram.city/play/?scene=https://raw.githubusercontent.com/ENT8R/streetcomplete-mapstyle/jawg/streetcomplete-satellite-style.yaml), [Dark map](https://tangram.city/play/?scene=https://raw.githubusercontent.com/ENT8R/streetcomplete-mapstyle/jawg/streetcomplete-dark-style.yaml))  
+    When using jawg.io, add your API key to the field `api_key` in the `global` section
 * Change or add something to the style
 * Download the file after you did your work
 * Make a pull request to this repository
 
 ## Useful links
 
+* [View map & edit map style](https://streetcomplete.github.io/streetcomplete-mapstyle)
 * [Tangram documentation](https://mapzen.com/documentation/tangram/)
 * [Tangram Play](https://tangram.city/play/)
-* [View map](https://streetcomplete.github.io/streetcomplete-mapstyle)
 * [Issue #183 of StreetComplete](https://github.com/westnordost/StreetComplete/issues/183) (The reason why this repository was created)


### PR DESCRIPTION
This makes it more obvious that the API key needs to be provided when using Tangram Play. See also the instructions provided at https://github.com/streetcomplete/streetcomplete-mapstyle/issues/87#issuecomment-700696337.