### PR TITLE
smarter label order

### DIFF
--- a/layers/labels.yaml
+++ b/layers/labels.yaml
@@ -25,7 +25,7 @@ layers:
             text:
                 text_source: global.name_source
                 buffer: 12px
-                priority: function() { return feature.scalerank }
+                priority: function() { 20 + return feature.scalerank }
                 font:
                     family: global.text_font_family
                     fill: global.text_water_color
@@ -69,7 +69,29 @@ layers:
             text:
                 text_source: global.name_source
                 buffer: 4px
-                priority: function() { return 10 + feature.scalerank }
+                priority: |
+                  function() {
+                      if(feature.type == "city") {
+                          return 10 + feature.scalerank;
+                      }
+                      if(feature.type == "town") {
+                          return 10 + feature.scalerank + 1;
+                      }
+                      if(feature.type == "village") {
+                          return 10 + feature.scalerank + 2;
+                      }
+                      if(feature.type == "hamlet") {
+                          return 10 + feature.scalerank + 3;
+                      }
+                      if(feature.type == "suburb") {
+                          return 10 + feature.scalerank + 4;
+                      }
+                      if(feature.type == "neighbourhood") {
+                          return 10 + feature.scalerank + 5;
+                      }
+                      /* note that locality and isolated_dwelling are not supported in Jawg */
+                      return 10 + feature.scalerank + 6;
+                  }
                 font:
                     family: global.text_font_family
                     fill: global.text_fill_color


### PR DESCRIPTION
previously village and town could have the same scalerank, with unimportant label obscuring more important

also, water label could obscure town label (at least theoretically)

fixes #113

The open questions:

is it necessary to do the same for other map branches? Probably not worth time for investigating is similar poor ordering present also there

it is possible to apply the very similar solution for having different label sizes (and actually I used it for debugging)

I plan on merging it after one extra testing round (when I am less sleepy) and after giving people time for checking it, but I am quite certain about this

note: to make testing easier label size can be bumped, for example with

```
                font:
                    family: global.text_font_family
                    fill: global.text_fill_color
                    size: |
                      function() {
                          if(feature.type == "city") {
                              return "30px";
                          }
                          if(feature.type == "town") {
                              return "25px";
                          }
                          if(feature.type == "village") {
                              return "20px";
                          }
                          if(feature.type == "hamlet") {
                              return "15px";
                          }
                          if(feature.type == "suburb") {
                              return "10px";
                          }
                          if(feature.type == "neighbourhood") {
                              return "5px";
                          }
                          return "100px";
                      }
                    stroke: global.text_places_stroke
```