### PR TITLE
Display bridges and piers

### DIFF
--- a/layers/land.yaml
+++ b/layers/land.yaml
@@ -143,6 +143,13 @@ layers:
                     order: 100
                     color: '#f9f9f9'
 
+    bridges:
+        data: { source: jawg, layer: structure }
+        filter: { class: bridge }
+        draw:
+            polygons:
+                order: 10
+                color: global.building_color
 
 styles:
     hillshade-light-style:

--- a/layers/land.yaml
+++ b/layers/land.yaml
@@ -149,7 +149,7 @@ layers:
         draw:
             polygons:
                 order: 10
-                color: global.building_color
+                color: global.building_outline_color
 
 styles:
     hillshade-light-style:


### PR DESCRIPTION
fixes #86 and #101

Bridge structures and piers are now displayed with the same color as buildings.

Order is higher than water/landuse and lower than anything else. This means bridges are displayed below ways that actually go under the bridge. Not really nice, but same as in standard style on openstreetmap.org.