### PR TITLE
Display squares at more zoom levels

### DIFF
--- a/layers/land.yaml
+++ b/layers/land.yaml
@@ -118,7 +118,7 @@ layers:
     pedestrian-areas:
         data: { source: jawg , layer: road }
         squares:
-            filter: { class: street_limited, type: pedestrian , $zoom: { min: 17 } }
+            filter: { class: street_limited, type: pedestrian , $zoom: { min: 14 } }
             draw:
                 lines:
                     color: global.square_outline_color


### PR DESCRIPTION
fixes #115 

Currently when zooming out, squares look "empty", only the outlines are displayed as roads.

When switching the min zoom from 17 to 14, squares disapper together with many roads and there are no "empty" squares.