### PR TITLE
Display footpath tunnels in same style as road tunnels

### DIFF
--- a/layers/roads.yaml
+++ b/layers/roads.yaml
@@ -104,11 +104,8 @@ layers:
                 filter: { structure: tunnel }
                 draw:
                     lines-road-style:
-                        order: 20
                         style: tunnel-way
                         color: global.tunnel_color
-                        outline:
-                            order: 21
             steps:
                 filter: { type: steps }
                 draw:

--- a/layers/roads.yaml
+++ b/layers/roads.yaml
@@ -100,6 +100,15 @@ layers:
                 lines-road-style:
                     color: global.path_color
                     width: [[14, 0.5px], [15, 1px], [19, 2m]]
+            path-tunnel:
+                filter: { structure: tunnel }
+                draw:
+                    lines-road-style:
+                        order: 20
+                        style: tunnel-way
+                        color: global.tunnel_color
+                        outline:
+                            order: 21
             steps:
                 filter: { type: steps }
                 draw:


### PR DESCRIPTION
fixes #114 by copying the `tunnel` style to a `path-tunnel` style.
I am not really sure why it works this way, but not how it is done currently.

Maybe some of the copied lines are unnecessary and can be removed, but I did not (yet) test too much, as display of footpath tunnels looks different in SC app and on https://streetcomplete.github.io/streetcomplete-mapstyle/?provider=jawg and thus testing is much slower (don't have a working emulator).
