### PR TITLE
Display steps on bridges

### DIFF
--- a/layers/roads.yaml
+++ b/layers/roads.yaml
@@ -108,6 +108,11 @@ layers:
                         cap: butt
                         color: global.path_color
                         width: [[14, 0.5px], [15, 1px], [19, 2m]]
+                bridge-steps:
+                    filter: { structure: bridge }
+                    draw:
+                        step_dashes:
+                            order: 41
 
         road-outline:
             filter: { $zoom: { min: 15 } }


### PR DESCRIPTION
fixes #93 

This adjusts the order of `steps-dashes` on bridges, so they are displayed above the bridge path (order 40).