### PR TITLE
Consider officially archiving other branches?

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ It is designed to not visually distract the user from the quests that are displa
 
 Every vector map tiles hoster has his own schema, so every map style is per se only compatible with the schema it was created for. The style was originally created for are for the [mapzen/nextzen](https://www.nextzen.org/) schema. However, it has been adapted to work (with some reservations) with other vector tile schemes as well. It is available for:
 
-- [nextzen](https://www.nextzen.org/) on the [`nextzen`](https://github.com/streetcomplete/streetcomplete-mapstyle/tree/nextzen) branch
-- [openmaptiles](https://openmaptiles.org/schema/) on branch [`openmaptiles`](https://github.com/streetcomplete/streetcomplete-mapstyle/tree/openmaptiles)
-- [jawg.io](https://www.jawg.io/en/maps) on branch [`jawg`](https://github.com/streetcomplete/streetcomplete-mapstyle/tree/jawg)
-- [thunderforest outdoors](https://www.thunderforest.com/docs/thunderforest.outdoors-v2/) on branch [`thunderforest`](https://github.com/streetcomplete/streetcomplete-mapstyle/tree/thunderforest)
+- [jawg.io](https://www.jawg.io/en/maps) on branch [`jawg`](https://github.com/streetcomplete/streetcomplete-mapstyle/tree/jawg) which is used in StreetComplete and is maintained
+- [nextzen](https://www.nextzen.org/) on the [`nextzen`](https://github.com/streetcomplete/streetcomplete-mapstyle/tree/nextzen) branch - not maintained, was used by StreetComplete in past
+- [openmaptiles](https://openmaptiles.org/schema/) on branch [`openmaptiles`](https://github.com/streetcomplete/streetcomplete-mapstyle/tree/openmaptiles) - was created to test various tile providers for StreetComplete and is not maintained
+- [thunderforest outdoors](https://www.thunderforest.com/docs/thunderforest.outdoors-v2/) on branch [`thunderforest`](https://github.com/streetcomplete/streetcomplete-mapstyle/tree/thunderforest) - was created to test various tile providers for StreetComplete and is not maintained
+
+While improving map style it is fine to edit just `jawg` branch. Fixes to other branches are also welcome, but code there is not guaranteed to work.
 
 ## Contributing
 


### PR DESCRIPTION
Right now this repository has multiple branches, but only Jawg is used.

While I am not proposing to delete other ones (maybe they will be used in future), but I think that it is fine to make new improvements solely to jawg branch

See https://github.com/streetcomplete/streetcomplete-mapstyle/pull/123#issuecomment-1122192158 "TBH i stopped maintaining those branches. As far as i know, SC is the sole user of this stylesheet anyway."