### PR TITLE
Remove fancy style for railways and highways

### DIFF
--- a/streetcomplete-dark-style.yaml
+++ b/streetcomplete-dark-style.yaml
@@ -43,12 +43,6 @@ global:
     tunnel_color: [0.3, 0.2, 1.0, 0.2]
 
 styles:
-    lines-highway-style:
-        base: lines
-        blend: add
-    lines-railway-style:
-        base: lines
-        blend: add
     buildings-style:
         base: polygons
         blend: translucent

--- a/streetcomplete-dark-style.yaml
+++ b/streetcomplete-dark-style.yaml
@@ -17,11 +17,11 @@ global:
     text_fill_color: '#ccf'
     text_water_color: '#ccf'
 
-    railway_color: '#903'
+    railway_color: '#96c'
     road_color: '#559'
     road_outline_color: '#99f'
-    highway_color: '#033'
-    highway_outline_color: '#000'
+    highway_color: '#669'
+    highway_outline_color: global.road_outline_color
     path_color: global.road_color
     path_outline_color: '#547'
     square_color: global.road_color


### PR DESCRIPTION
fixes #84 
fixes #107

This removes the `blend: add` which creates the bright and transparent style for raiways and highways.
Before:
![default](https://user-images.githubusercontent.com/43007630/174467524-a60bae3f-5488-4715-a734-1d5589aeb707.jpg)
After:
![no_add](https://user-images.githubusercontent.com/43007630/174467682-972220a3-9e53-46af-bbf5-95568b2524db.png)
The colors could be adjusted a little bit as well. Inmy opinion railways still stand out a little too much, and highways look a bit too green. Some small changes using `#603` for railway and `#144` for highway:
![no_add_603_144](https://user-images.githubusercontent.com/43007630/174467687-fae71a82-6bcc-4486-b6a4-c2e3090f9f5c.png)
