### PR TITLE
Display underground steps similar to underground paths

### DIFF
--- a/layers/roads.yaml
+++ b/layers/roads.yaml
@@ -107,7 +107,7 @@ layers:
                         style: tunnel-way
                         color: global.tunnel_color
             steps:
-                filter: { type: steps }
+                filter: { type: steps, not: { structure: tunnel } }
                 draw:
                     step_dashes:
                         order: 31
@@ -119,6 +119,14 @@ layers:
                     draw:
                         step_dashes:
                             order: 41
+            steps-tunnel:
+                filter: { type: steps, structure: tunnel }
+                draw:
+                    step_dashes:
+                        order: 21
+                        cap: butt
+                        color: global.tunnel_color
+                        width: [[14, 0.5px], [15, 1px], [19, 2m]]
 
         road-outline:
             filter: { $zoom: { min: 15 } }


### PR DESCRIPTION
Currently underground steps are shown using the same style as on ground level, which leads to two issues:
* underground steps are not shown in translucent color, while underground paths are, so it may looks like the steps are higher than nearby underground paths
* step dashes have the same order as road/path outlines, which puts dashes of underground steps above roads / paths that actually are on ground level above the steps.

Both are fixed in this PR.