### PR TITLE
show man_made=pier as ways too

### DIFF
--- a/layers/land.yaml
+++ b/layers/land.yaml
@@ -147,6 +147,10 @@ layers:
         data: { source: jawg, layer: structure }
         filter: { class: bridge }
         draw:
+            lines:
+                order: 9
+                width: 4
+                color: global.building_outline_color
             polygons:
                 order: 10
                 color: global.building_outline_color


### PR DESCRIPTION
Previous PR (see https://github.com/streetcomplete/streetcomplete-mapstyle/pull/122#issuecomment-1235137328) was only showing them when drawn as polygons.

This adds support when they are drawn as ways too
I've tested both at https://streetcomplete.github.io/streetcomplete-mapstyle/ and in app (by manually applying the patch [there](https://github.com/mnalis/StreetComplete/actions/runs/2981557922) too), and it seems to me to work fine. 

Before & after pics:
![small_Screenshot_20220902_003308_de westnordost streetcomplete](https://user-images.githubusercontent.com/156656/188024376-128c0dfb-9ef0-4bea-9bd1-40ce61939219.jpg) ![small_Screenshot_20220902_221608_de westnordost streetcomplete mn debug](https://user-images.githubusercontent.com/156656/188229922-0a0aa7a1-2cdb-488f-a760-c1d15ab830b7.jpg)
