### PR TITLE
Reapply building color transparency workaround

### DIFF
--- a/streetcomplete-dark-style.yaml
+++ b/streetcomplete-dark-style.yaml
@@ -32,8 +32,9 @@ global:
     forest_color: '#403962'
     town_color: '#3d364e'
 
-    building_color: [0.16, 0.36, 0.36, 0.75]
-    building_outline_color: [0.12, 0.32, 0.32, 0.75]
+    # alpha is shown as double of what is specified https://github.com/tangrams/tangram-es/issues/2333
+    building_color: [0.16, 0.36, 0.36, 0.4]
+    building_outline_color: [0.12, 0.32, 0.32, 0.4]
 
     boundary_color: '#e72'
 

--- a/streetcomplete-light-style.yaml
+++ b/streetcomplete-light-style.yaml
@@ -26,8 +26,9 @@ global:
     forest_color: '#a8c884'
     town_color: '#f3dacd'
 
-    building_color: rgba(204, 214, 238, .75)
-    building_outline_color: rgba(185, 195, 217, .75)
+    # alpha is shown as double of what is specified https://github.com/tangrams/tangram-es/issues/2333
+    building_color: rgba(204, 214, 238, 0.4)
+    building_outline_color: rgba(185, 195, 217, 0.4)
 
     boundary_color: '#f3c'
 


### PR DESCRIPTION
This commit https://github.com/streetcomplete/StreetComplete/commit/da33482dcf1832c3f6e1d71b15a423c50420f04a got lost in https://github.com/streetcomplete/StreetComplete/commit/397143051951155d1ceff4f41714e61bc988e4bc, since the fix was not done in this repo. This commit reapplies the change.